### PR TITLE
fix: Apply gateway class correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default > dist/install.yaml
+	$(KUSTOMIZE) build config > dist/install.yaml
 
 .PHONY: flux-push
 flux-push: manifests generate kustomize ## Push the manifests to a oci repository for FluxCD to consume.
@@ -290,11 +290,11 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Dependencies
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,7 +18,6 @@ resources:
 #- ../crd
 - ../rbac
 - ../manager
-- ../install
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Combines the operator deployment (with namePrefix) and the cluster-scoped
+# ToolGatewayClass registration (without namePrefix, so the class keeps a stable,
+# conventional name like "agentgateway" that users reference in ToolGateway resources).
+resources:
+- ./default
+- ./install

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -3,6 +3,7 @@
 resources:
 - bases/tool-gateway-agentgateway.clusterserviceversion.yaml
 - ../default
+- ../install
 - ../samples
 - ../scorecard
 

--- a/config/samples/toolgateway_v1alpha1_otel_example.yaml
+++ b/config/samples/toolgateway_v1alpha1_otel_example.yaml
@@ -13,18 +13,6 @@ kind: Namespace
 metadata:
   name: tool-gateway
 
-# ToolGatewayClass - defines the controller implementation
----
-apiVersion: runtime.agentic-layer.ai/v1alpha1
-kind: ToolGatewayClass
-metadata:
-  name: agentgateway
-  namespace: tool-gateway
-  annotations:
-    toolgatewayclass.kubernetes.io/is-default-class: "true"
-spec:
-  controller: runtime.agentic-layer.ai/tool-gateway-agentgateway-controller
-
 # ToolGateway with OTEL configuration
 # The OTEL env vars below will be translated to agentgateway's rawConfig.telemetry section
 ---
@@ -43,7 +31,7 @@ spec:
       value: "http/protobuf"
     - name: OTEL_EXPORTER_OTLP_HEADERS
       value: "api-key=my-secret-key,environment=production"
-    
+
     # Non-OTEL env vars - these will be passed through as-is
     - name: LOG_LEVEL
       value: "info"
@@ -84,7 +72,7 @@ spec:
       value: "http://otel-collector:4318"
     - name: OTEL_EXPORTER_OTLP_PROTOCOL
       value: "http/protobuf"
-    
+
     # Signal-specific configuration overrides
     - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
       value: "http://jaeger-collector:4318"
@@ -92,7 +80,7 @@ spec:
       value: "grpc"
     - name: OTEL_EXPORTER_OTLP_TRACES_HEADERS
       value: "trace-api-key=trace-secret"
-    
+
     # Regular env vars
     - name: SERVICE_NAME
       value: "my-service"

--- a/config/samples/toolgateway_v1alpha1_toolgateway_with_toolserver.yaml
+++ b/config/samples/toolgateway_v1alpha1_toolgateway_with_toolserver.yaml
@@ -23,18 +23,6 @@ kind: Namespace
 metadata:
   name: namespace-b
 
-# ToolGatewayClass - defines the controller implementation
----
-apiVersion: runtime.agentic-layer.ai/v1alpha1
-kind: ToolGatewayClass
-metadata:
-  name: agentgateway
-  namespace: tool-gateway
-  annotations:
-    toolgatewayclass.kubernetes.io/is-default-class: "true"
-spec:
-  controller: runtime.agentic-layer.ai/tool-gateway-agentgateway-controller
-
 # ConfigMap referenced by the ToolGateway envFrom
 ---
 apiVersion: v1

--- a/docs/modules/operator/partials/how-to-guide.adoc
+++ b/docs/modules/operator/partials/how-to-guide.adoc
@@ -116,7 +116,7 @@ spec:
     kind: OCIRepository
     name: tool-gateway-agentgateway
   interval: 10m
-  path: ./default
+  path: ./
   prune: true
   wait: true
   dependsOn:

--- a/internal/controller/test_utils.go
+++ b/internal/controller/test_utils.go
@@ -21,10 +21,56 @@ import (
 
 	agentruntimev1alpha1 "github.com/agentic-layer/agent-runtime-operator/api/v1alpha1"
 	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+// defaultTestToolGatewayClassName matches the class shipped by the operator
+// install kustomization (config/install/toolgatewayclass.yaml). Tests use the
+// same name so that class lookups behave like a real cluster.
+const defaultTestToolGatewayClassName = "agentgateway"
+
+// createDefaultToolGatewayClass installs the production-realistic default
+// ToolGatewayClass: the conventional name, this operator's controller string,
+// and the is-default-class annotation. Any ToolGateway without an explicit
+// ToolGatewayClassName picks this one up.
+func createDefaultToolGatewayClass(ctx context.Context, k8sClient client.Client) {
+	class := &agentruntimev1alpha1.ToolGatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultTestToolGatewayClassName,
+			Annotations: map[string]string{
+				toolGatewayClassDefaultAnnotation: "true",
+			},
+		},
+		Spec: agentruntimev1alpha1.ToolGatewayClassSpec{
+			Controller: ToolGatewayAgentgatewayControllerName,
+		},
+	}
+	gomega.Expect(k8sClient.Create(ctx, class)).To(gomega.Succeed())
+}
+
+// cleanupToolGatewayClasses removes every ToolGatewayClass in the cluster.
+// ToolGatewayClasses are cluster-scoped, so this is the equivalent of
+// cleanupTestResources for that kind. Safe to call when none exist.
+func cleanupToolGatewayClasses(ctx context.Context, k8sClient client.Client) {
+	classList := &agentruntimev1alpha1.ToolGatewayClassList{}
+	gomega.Expect(k8sClient.List(ctx, classList)).To(gomega.Succeed())
+	for i := range classList.Items {
+		err := k8sClient.Delete(ctx, &classList.Items[i])
+		if err != nil && !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	}
+	// Wait for deletions to settle so the next test starts from a clean slate.
+	gomega.Eventually(func() int {
+		remaining := &agentruntimev1alpha1.ToolGatewayClassList{}
+		_ = k8sClient.List(ctx, remaining)
+		return len(remaining.Items)
+	}, "5s", "100ms").Should(gomega.Equal(0))
+}
 
 // cleanupTestResources cleans up all test resources in the specified namespace.
 // This is a shared utility function used by both ToolGateway and ToolRoute tests.
@@ -48,13 +94,6 @@ func cleanupTestResources(ctx context.Context, k8sClient client.Client, namespac
 	gomega.Expect(k8sClient.List(ctx, toolGatewayList, &client.ListOptions{Namespace: namespace})).To(gomega.Succeed())
 	for i := range toolGatewayList.Items {
 		_ = k8sClient.Delete(ctx, &toolGatewayList.Items[i])
-	}
-
-	// Clean up all tool gateway classes (cluster-scoped)
-	toolGatewayClassList := &agentruntimev1alpha1.ToolGatewayClassList{}
-	gomega.Expect(k8sClient.List(ctx, toolGatewayClassList)).To(gomega.Succeed())
-	for i := range toolGatewayClassList.Items {
-		_ = k8sClient.Delete(ctx, &toolGatewayClassList.Items[i])
 	}
 
 	// Clean up all HTTPRoutes in the namespace

--- a/internal/controller/toolgateway_reconciler_test.go
+++ b/internal/controller/toolgateway_reconciler_test.go
@@ -44,43 +44,20 @@ var _ = Describe("ToolGateway Controller", func() {
 			Scheme:   k8sClient.Scheme(),
 			Recorder: kevents.NewFakeRecorder(100),
 		}
+		createDefaultToolGatewayClass(ctx, k8sClient)
 	})
 
 	AfterEach(func() {
 		cleanupTestResources(ctx, k8sClient, "default")
+		cleanupToolGatewayClasses(ctx, k8sClient)
 	})
 
 	Describe("Reconcile", func() {
-		It("should create ToolGatewayClass", func() {
-			toolGatewayClass := &agentruntimev1alpha1.ToolGatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-class",
-				},
-				Spec: agentruntimev1alpha1.ToolGatewayClassSpec{
-					Controller: "runtime.agentic-layer.ai/tool-gateway-agentgateway-controller",
-				},
-			}
-			Expect(k8sClient.Create(ctx, toolGatewayClass)).To(Succeed())
-		})
-
 		It("should create ToolGateway and reconcile to create Gateway", func() {
-			toolGatewayClass := &agentruntimev1alpha1.ToolGatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-class-2",
-				},
-				Spec: agentruntimev1alpha1.ToolGatewayClassSpec{
-					Controller: "runtime.agentic-layer.ai/tool-gateway-agentgateway-controller",
-				},
-			}
-			Expect(k8sClient.Create(ctx, toolGatewayClass)).To(Succeed())
-
 			toolGateway := &agentruntimev1alpha1.ToolGateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-basic-gateway",
 					Namespace: "default",
-				},
-				Spec: agentruntimev1alpha1.ToolGatewaySpec{
-					ToolGatewayClassName: "test-class-2",
 				},
 			}
 			Expect(k8sClient.Create(ctx, toolGateway)).To(Succeed())
@@ -145,23 +122,10 @@ var _ = Describe("ToolGateway Controller", func() {
 		})
 
 		It("should restore Gateway to desired state after drift", func() {
-			toolGatewayClass := &agentruntimev1alpha1.ToolGatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-class-drift",
-				},
-				Spec: agentruntimev1alpha1.ToolGatewayClassSpec{
-					Controller: "runtime.agentic-layer.ai/tool-gateway-agentgateway-controller",
-				},
-			}
-			Expect(k8sClient.Create(ctx, toolGatewayClass)).To(Succeed())
-
 			toolGateway := &agentruntimev1alpha1.ToolGateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-drift-gateway",
 					Namespace: "default",
-				},
-				Spec: agentruntimev1alpha1.ToolGatewaySpec{
-					ToolGatewayClassName: "test-class-drift",
 				},
 			}
 			Expect(k8sClient.Create(ctx, toolGateway)).To(Succeed())
@@ -220,16 +184,12 @@ var _ = Describe("ToolGateway Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should not reconcile ToolGateway with wrong controller", func() {
-			toolGatewayClass := &agentruntimev1alpha1.ToolGatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "wrong-controller-class",
-				},
-				Spec: agentruntimev1alpha1.ToolGatewayClassSpec{
-					Controller: "other-controller",
-				},
+		It("should not reconcile ToolGateway whose explicit class is owned by a different controller", func() {
+			foreignClass := &agentruntimev1alpha1.ToolGatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "wrong-controller-class"},
+				Spec:       agentruntimev1alpha1.ToolGatewayClassSpec{Controller: "other-controller"},
 			}
-			Expect(k8sClient.Create(ctx, toolGatewayClass)).To(Succeed())
+			Expect(k8sClient.Create(ctx, foreignClass)).To(Succeed())
 
 			toolGateway := &agentruntimev1alpha1.ToolGateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -250,6 +210,8 @@ var _ = Describe("ToolGateway Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
+			// Even though a default class owned by this controller exists, the
+			// explicit className must NOT fall back to it. No Gateway is created.
 			gateway := &gatewayv1.Gateway{}
 			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "test-wrong-controller",
@@ -259,16 +221,9 @@ var _ = Describe("ToolGateway Controller", func() {
 		})
 
 		It("should pass spec.env through to AgentgatewayParameters", func() {
-			toolGatewayClass := &agentruntimev1alpha1.ToolGatewayClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-class-env"},
-				Spec:       agentruntimev1alpha1.ToolGatewayClassSpec{Controller: "runtime.agentic-layer.ai/tool-gateway-agentgateway-controller"},
-			}
-			Expect(k8sClient.Create(ctx, toolGatewayClass)).To(Succeed())
-
 			toolGateway := &agentruntimev1alpha1.ToolGateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-env-gateway", Namespace: "default"},
 				Spec: agentruntimev1alpha1.ToolGatewaySpec{
-					ToolGatewayClassName: "test-class-env",
 					Env: []corev1.EnvVar{
 						{Name: "MY_VAR", Value: "my-value"},
 					},
@@ -303,16 +258,9 @@ var _ = Describe("ToolGateway Controller", func() {
 		})
 
 		It("should pass spec.envFrom through to AgentgatewayParameters deployment spec", func() {
-			toolGatewayClass := &agentruntimev1alpha1.ToolGatewayClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-class-envfrom"},
-				Spec:       agentruntimev1alpha1.ToolGatewayClassSpec{Controller: "runtime.agentic-layer.ai/tool-gateway-agentgateway-controller"},
-			}
-			Expect(k8sClient.Create(ctx, toolGatewayClass)).To(Succeed())
-
 			toolGateway := &agentruntimev1alpha1.ToolGateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-envfrom-gateway", Namespace: "default"},
 				Spec: agentruntimev1alpha1.ToolGatewaySpec{
-					ToolGatewayClassName: "test-class-envfrom",
 					EnvFrom: []corev1.EnvFromSource{
 						{ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"}}},
 					},
@@ -348,16 +296,9 @@ var _ = Describe("ToolGateway Controller", func() {
 		})
 
 		It("should update AgentgatewayParameters when spec.env changes", func() {
-			toolGatewayClass := &agentruntimev1alpha1.ToolGatewayClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-class-env-update"},
-				Spec:       agentruntimev1alpha1.ToolGatewayClassSpec{Controller: "runtime.agentic-layer.ai/tool-gateway-agentgateway-controller"},
-			}
-			Expect(k8sClient.Create(ctx, toolGatewayClass)).To(Succeed())
-
 			toolGateway := &agentruntimev1alpha1.ToolGateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-env-update-gateway", Namespace: "default"},
 				Spec: agentruntimev1alpha1.ToolGatewaySpec{
-					ToolGatewayClassName: "test-class-env-update",
 					Env: []corev1.EnvVar{
 						{Name: "MY_VAR", Value: "initial-value"},
 					},
@@ -425,16 +366,9 @@ var _ = Describe("ToolGateway Controller", func() {
 		})
 
 		It("should clear spec.rawConfig in AgentgatewayParameters when OTEL env vars are removed", func() {
-			toolGatewayClass := &agentruntimev1alpha1.ToolGatewayClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-class-otel-remove"},
-				Spec:       agentruntimev1alpha1.ToolGatewayClassSpec{Controller: "runtime.agentic-layer.ai/tool-gateway-agentgateway-controller"},
-			}
-			Expect(k8sClient.Create(ctx, toolGatewayClass)).To(Succeed())
-
 			toolGateway := &agentruntimev1alpha1.ToolGateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-otel-remove-gateway", Namespace: "default"},
 				Spec: agentruntimev1alpha1.ToolGatewaySpec{
-					ToolGatewayClassName: "test-class-otel-remove",
 					Env: []corev1.EnvVar{
 						{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://otel-collector:4318"},
 						{Name: "MY_VAR", Value: "my-value"},
@@ -495,17 +429,8 @@ var _ = Describe("ToolGateway Controller", func() {
 		})
 
 		It("should set Service type to ClusterIP in AgentgatewayParameters", func() {
-			toolGatewayClass := &agentruntimev1alpha1.ToolGatewayClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-class-service"},
-				Spec:       agentruntimev1alpha1.ToolGatewayClassSpec{Controller: "runtime.agentic-layer.ai/tool-gateway-agentgateway-controller"},
-			}
-			Expect(k8sClient.Create(ctx, toolGatewayClass)).To(Succeed())
-
 			toolGateway := &agentruntimev1alpha1.ToolGateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-service-gateway", Namespace: "default"},
-				Spec: agentruntimev1alpha1.ToolGatewaySpec{
-					ToolGatewayClassName: "test-class-service",
-				},
 			}
 			Expect(k8sClient.Create(ctx, toolGateway)).To(Succeed())
 			Eventually(func() error {

--- a/internal/controller/toolroute_reconciler_test.go
+++ b/internal/controller/toolroute_reconciler_test.go
@@ -44,10 +44,12 @@ var _ = Describe("ToolRouteReconciler", func() {
 			Scheme:   k8sClient.Scheme(),
 			Recorder: kevents.NewFakeRecorder(100),
 		}
+		createDefaultToolGatewayClass(ctx, k8sClient)
 	})
 
 	AfterEach(func() {
 		cleanupTestResources(ctx, k8sClient, ns)
+		cleanupToolGatewayClasses(ctx, k8sClient)
 	})
 
 	// reconcile is a helper that waits for resources to be visible in the cached
@@ -60,11 +62,11 @@ var _ = Describe("ToolRouteReconciler", func() {
 	}
 
 	It("skips a ToolRoute whose ToolGateway class is not owned by this controller", func() {
-		otherClass := &agentruntimev1alpha1.ToolGatewayClass{
+		foreignClass := &agentruntimev1alpha1.ToolGatewayClass{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr-other-class"},
 			Spec:       agentruntimev1alpha1.ToolGatewayClassSpec{Controller: "example.com/other"},
 		}
-		Expect(k8sClient.Create(ctx, otherClass)).To(Succeed())
+		Expect(k8sClient.Create(ctx, foreignClass)).To(Succeed())
 
 		tg := &agentruntimev1alpha1.ToolGateway{
 			ObjectMeta: metav1.ObjectMeta{Name: "foreign-tg", Namespace: ns},
@@ -97,15 +99,8 @@ var _ = Describe("ToolRouteReconciler", func() {
 	})
 
 	It("creates an AgentgatewayBackend and HTTPRoute for a cluster ToolServer upstream", func() {
-		ownClass := &agentruntimev1alpha1.ToolGatewayClass{
-			ObjectMeta: metav1.ObjectMeta{Name: "tr-own-class"},
-			Spec:       agentruntimev1alpha1.ToolGatewayClassSpec{Controller: ToolGatewayAgentgatewayControllerName},
-		}
-		Expect(k8sClient.Create(ctx, ownClass)).To(Succeed())
-
 		tg := &agentruntimev1alpha1.ToolGateway{
 			ObjectMeta: metav1.ObjectMeta{Name: "own-tg", Namespace: ns},
-			Spec:       agentruntimev1alpha1.ToolGatewaySpec{ToolGatewayClassName: "tr-own-class"},
 		}
 		Expect(k8sClient.Create(ctx, tg)).To(Succeed())
 
@@ -161,15 +156,8 @@ var _ = Describe("ToolRouteReconciler", func() {
 	})
 
 	It("creates a backend with a static host for an external upstream", func() {
-		ownClass := &agentruntimev1alpha1.ToolGatewayClass{
-			ObjectMeta: metav1.ObjectMeta{Name: "tr-own-class-ext"},
-			Spec:       agentruntimev1alpha1.ToolGatewayClassSpec{Controller: ToolGatewayAgentgatewayControllerName},
-		}
-		Expect(k8sClient.Create(ctx, ownClass)).To(Succeed())
-
 		tg := &agentruntimev1alpha1.ToolGateway{
 			ObjectMeta: metav1.ObjectMeta{Name: "own-tg-ext", Namespace: ns},
-			Spec:       agentruntimev1alpha1.ToolGatewaySpec{ToolGatewayClassName: "tr-own-class-ext"},
 		}
 		Expect(k8sClient.Create(ctx, tg)).To(Succeed())
 
@@ -202,15 +190,8 @@ var _ = Describe("ToolRouteReconciler", func() {
 	})
 
 	It("creates an AgentgatewayPolicy with CEL rules when toolFilter is set, and deletes it when filter is cleared", func() {
-		ownClass := &agentruntimev1alpha1.ToolGatewayClass{
-			ObjectMeta: metav1.ObjectMeta{Name: "tr-own-class-filter"},
-			Spec:       agentruntimev1alpha1.ToolGatewayClassSpec{Controller: ToolGatewayAgentgatewayControllerName},
-		}
-		Expect(k8sClient.Create(ctx, ownClass)).To(Succeed())
-
 		tg := &agentruntimev1alpha1.ToolGateway{
 			ObjectMeta: metav1.ObjectMeta{Name: "own-tg-filter", Namespace: ns},
-			Spec:       agentruntimev1alpha1.ToolGatewaySpec{ToolGatewayClassName: "tr-own-class-filter"},
 		}
 		Expect(k8sClient.Create(ctx, tg)).To(Succeed())
 


### PR DESCRIPTION
This is a breaking change for flux deployments: Instead of ./default, ./ must be applied.