### PR TITLE
feat!: Stop shipping ToolGatewayClass as cluster-default

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ metadata:
   name: my-tool-gateway
   namespace: my-namespace
 spec:
-  toolGatewayClassName: agentgateway  # Optional: uses default if not specified
+  toolGatewayClassName: agentgateway  # Optional; required unless a ToolGatewayClass is marked default
 ```
 
 This will create a `my-tool-gateway` Gateway in the `my-namespace` namespace.

--- a/config/install/toolgatewayclass.yaml
+++ b/config/install/toolgatewayclass.yaml
@@ -2,7 +2,5 @@ apiVersion: runtime.agentic-layer.ai/v1alpha1
 kind: ToolGatewayClass
 metadata:
   name: agentgateway
-  annotations:
-    toolgatewayclass.kubernetes.io/is-default-class: "true"
 spec:
   controller: runtime.agentic-layer.ai/tool-gateway-agentgateway-controller

--- a/docs/modules/operator/partials/reference.adoc
+++ b/docs/modules/operator/partials/reference.adoc
@@ -30,7 +30,7 @@ metadata:
   name: my-tool-gateway
   namespace: my-namespace
 spec:
-  toolGatewayClassName: agentgateway  # Optional: uses default if not specified
+  toolGatewayClassName: agentgateway  # Optional; required unless a ToolGatewayClass is marked default
   env:                                 # Optional: environment variables
     - name: LOG_LEVEL
       value: "info"
@@ -86,12 +86,36 @@ apiVersion: runtime.agentic-layer.ai/v1alpha1
 kind: ToolGatewayClass
 metadata:
   name: agentgateway
-  namespace: tool-gateway
-  annotations:
-    toolgatewayclass.kubernetes.io/is-default-class: "true"
 spec:
   controller: runtime.agentic-layer.ai/tool-gateway-agentgateway-controller
 ----
+
+==== Marking a ToolGatewayClass as default
+
+The shipped `agentgateway` `ToolGatewayClass` is **not** marked as the cluster
+default. To claim `ToolGateway` resources that omit `spec.toolGatewayClassName`,
+either set the field explicitly on every `ToolGateway`, or add the
+`toolgatewayclass.kubernetes.io/is-default-class: "true"` annotation via a
+Kustomize overlay:
+
+[source,yaml]
+----
+# kustomization.yaml
+resources:
+  - https://github.com/agentic-layer/tool-gateway-agentgateway/releases/latest/download/install.yaml
+patches:
+  - patch: |-
+      apiVersion: runtime.agentic-layer.ai/v1alpha1
+      kind: ToolGatewayClass
+      metadata:
+        name: agentgateway
+        annotations:
+          toolgatewayclass.kubernetes.io/is-default-class: "true"
+----
+
+Use this only when this operator is the single Tool Gateway implementation in
+the cluster — multiple defaults across operators produce non-deterministic
+ownership of unlabeled `ToolGateway` resources.
 
 === ToolServer
 


### PR DESCRIPTION
Remove the toolgatewayclass.kubernetes.io/is-default-class annotation from the shipped agentgateway ToolGatewayClass so multiple Tool Gateway operators can coexist without colliding for unlabeled ToolGateways. Document a Kustomize overlay for users who want to opt back in.

BREAKING CHANGE: ToolGateway resources that previously relied on implicit class defaulting will become unowned by this controller after upgrade. Remediation: set spec.toolGatewayClassName=agentgateway on existing ToolGateways, or apply the kustomize patch documented in the operator reference.